### PR TITLE
feat: 🎸 发送url文件支持自定义文件名

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ docker logs -f wxBotWebhook
 | -- | -- | -- | -- | -- | -- |
 | type | **消息类型**, 字段留空解析为纯文本 | `String`  `text` | - | Y | `text`  `fileUrl` | 支持 **文字** 和 **文件**，  |
 | content | **消息内容**，如果希望发多个Url并解析，type 指定为 fileUrl 同时，content 里填 url 以英文逗号分隔 | `String` | - | N | - |
+| customFileName | **自定义文件名**，仅在 type 为 fileUrl 时有效，用于自定义发送的文件的文件名 | `String` | - | Y | - |
+
 
 #### Example（curl）
 
@@ -182,7 +184,11 @@ curl --location 'http://localhost:3001/webhook/msg/v2?token=[YOUR_PERSONAL_TOKEN
 --data '{
     "to": "testGroup",
     "isRoom": true,
-    "data": { "type": "fileUrl" , "content": "https://download.samplelib.com/jpeg/sample-clouds-400x300.jpg" },
+    "data": {
+        "type": "fileUrl" ,
+        "content": "https://download.samplelib.com/jpeg/sample-clouds-400x300.jpg",
+        "customFileName": "cloud.jpg"
+    }
 }'
 ```
 

--- a/src/route/msg.js
+++ b/src/route/msg.js
@@ -154,6 +154,7 @@ function registerPushHook({ app, bot }) {
         bot,
         type,
         content,
+        customFileName: "",
         msgInstance: msgReceiver
       })
 

--- a/src/service/msgSender.js
+++ b/src/service/msgSender.js
@@ -360,7 +360,7 @@ const handleMsg2Single = async function (body, { bot, messageReceiver }) {
     /** @type {boolean| undefined} */
     isRoom: body.isRoom,
     /** @type {pushMsgUnitTypeOpt | pushMsgUnitTypeOpt[]} */
-    data: body.data /** { "type": "", content: "" } */,
+    data: body.data /** { "type": "", content: "", customFileName: "" } */,
     unValidParamsStr: ''
   }
 
@@ -391,6 +391,7 @@ const handleMsg2Single = async function (body, { bot, messageReceiver }) {
           type: msgArr[i].type || 'text',
           // @ts-ignore
           content: msgArr[i].content,
+          customFileName: msgArr[i].customFileName || '',
           msgInstance: msgReceiver
         })
         msgArr[i].success = success
@@ -424,6 +425,7 @@ const handleMsg2Single = async function (body, { bot, messageReceiver }) {
         type: payload.data.type ?? 'text',
         // @ts-ignore
         content: payload.data.content,
+        customFileName: payload.data.customFileName || '',
         msgInstance: msgReceiver
       })
 
@@ -476,7 +478,7 @@ const getPushMsgUnitUnvalidStr = function ({ type, content }) {
 /**
  * 发送消息核心。这个处理程序将数据转换为标准格式，然后使用 wechaty 发送消息。
  * @type {{
- * (payload:{ isRoom?: boolean,bot:import('wechaty/impls').WechatyInterface, type: 'text' | 'fileUrl'|'file', content: string| payloadFormFile, msgInstance: msgInstanceType }) : Promise<{success:boolean, error:any}>;
+ * (payload:{ isRoom?: boolean,bot:import('wechaty/impls').WechatyInterface, type: 'text' | 'fileUrl'|'file', content: string| payloadFormFile, customFileName: string, msgInstance: msgInstanceType }) : Promise<{success:boolean, error:any}>;
  * }}
  */
 const formatAndSendMsg = async function ({
@@ -484,6 +486,7 @@ const formatAndSendMsg = async function ({
   bot,
   type,
   content,
+  customFileName,
   msgInstance
 }) {
   let success = false
@@ -526,7 +529,7 @@ const formatAndSendMsg = async function ({
         // 单文件
         if (fileUrlArr.length === 1) {
           //@ts-expect-errors 重载不是很好使，手动判断
-          const file = await Utils.getMediaFromUrl(content)
+          const file = await Utils.getMediaFromUrl(content, customFileName)
           //@ts-expect-errors 重载不是很好使，手动判断
           emitPayload.content = file
           await msgInstance.say(file)
@@ -536,7 +539,7 @@ const formatAndSendMsg = async function ({
 
         // 多个文件的情况
         for (let i = 0; i < fileUrlArr.length; i++) {
-          const file = await Utils.getMediaFromUrl(fileUrlArr[i])
+          const file = await Utils.getMediaFromUrl(fileUrlArr[i], customFileName)
           //@ts-expect-errors 重载不是很好使，手动判断
           emitPayload.content = file
           await msgInstance.say(file)

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,15 +4,16 @@ const { logger } = require('./log')
 /**
  * 下载媒体文件转化为Buffer
  * @param {string} fileUrl
+ * @param {string} customFileName
  * @returns {Promise<{buffer?: Buffer, fileName?: string}>}
  */
-const downloadFile = async (fileUrl) => {
+const downloadFile = async (fileUrl,customFileName) => {
   try {
     const response = await fetch(fileUrl)
 
     if (response.ok) {
       const buffer = Buffer.from(await response.arrayBuffer())
-      let fileName = getFileNameFromUrl(fileUrl)
+      let fileName = customFileName || getFileNameFromUrl(fileUrl)
 
       // deal with unValid Url format like https://pangji-home.com/Fi5DimeGHBLQ3KcELn3DolvENjVU
       if (fileName === '') {
@@ -60,10 +61,11 @@ const getFileNameFromUrl = (url) => {
 /**
  * 根据url下载文件并转化成FileBox的标准格式
  * @param {string} url
+ * @param {string} customFileName
  * @returns {Promise<import('file-box').FileBoxInterface>}
  */
-const getMediaFromUrl = async (url) => {
-  const { buffer, fileName } = await downloadFile(url)
+const getMediaFromUrl = async (url, customFileName) => {
+  const { buffer, fileName } = await downloadFile(url, customFileName)
   //@ts-expect-errors buffer 解析是吧的情况
   return FileBox.fromBuffer(buffer, fileName)
 }

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -25,9 +25,9 @@ type pushMsgValidPayload = {
 
 type payloadFormFile = File & { convertName: string }
 
-type pushMsgUnitPayload = { type: 'text' | 'fileUrl'; content: string }
+type pushMsgUnitPayload = { type: 'text' | 'fileUrl'; content: string, customFileName?: string}
 
-type pushMsgUnitTypeOpt = { type?: 'text' | 'fileUrl'; content?: string }
+type pushMsgUnitTypeOpt = { type?: 'text' | 'fileUrl'; content?: string, customFileName?: string}
 
 type toType = string | { alias: string }
 


### PR DESCRIPTION
发送 URL 文件即 fileUrl 类型消息时，支持自定义文件名，解决 URL 无文件后缀时发送的文件被微信解析成不正确的后缀名问题。